### PR TITLE
Using Underscore.string's global (rather than mixin) and modifying filter name

### DIFF
--- a/angular-underscore-string.js
+++ b/angular-underscore-string.js
@@ -7,20 +7,20 @@
  *
  * Examples:
  *
- *     {{ name | _.str: 'swapCase' }}
- *     {{ separator | _.str: 'join': ['foo', 'bar'] }}
+ *     {{ name | s: 'swapCase' }}
+ *     {{ separator | s: 'join': ['foo', 'bar'] }}
  *
- * @param {String} str String to filter
+ * @param {String} s String to filter
  * @param {String} fn Underscore.string function to call
  * @param {[params]} params Extra parameters to pass to Underscore.string
  * @return {String} Filtered string
  */
 angular.module('underscore.string', [])
-  .filter('_.str', function() {
+  .filter('s', function() {
     return function(str, fn, params) {
       str = str || '';
       params = params || [];
       params.unshift(str);
-      return fn ? _.str[fn].apply(this, params) : str;
+      return fn ? s[fn].apply(this, params) : str;
     };
   });

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-underscore-string",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "authors": [
     "Tom Vincent <git@tlvince.com>"
   ],


### PR DESCRIPTION
Hey what's up @tlvince, great idea adding this filter.  I'm moving a few external libs into angular and was happy to see this package existed as I was searching for a solution for `underscore.string`

I noticed the filter provided uses the `_.str` mixin.  The latest `underscore.string` exposes a global (`s`) that will work without having to manually mixin to underscore/lo-dash. There's a few things that are overridden when doing so so it looks [like it's no longer recommended](https://github.com/epeli/underscore.string#underscorejslo-dash-integration).  With that in mind, I made a tiny change to use the `s` global in the filter.  

I also with the angular 1.2+ i  was unable to to get the filter working with it named `_.str`. I think the period is conflicting with angular `FilterProvider`. Renaming it `_str` gets it back working.

Let me know if these changes make sense to you?  Only took a second so I wanted to send em over in case anyone else wants to leverage the code you started. 

Thanks for adding this!
